### PR TITLE
Fixes

### DIFF
--- a/src/vlog/async_fifo.v
+++ b/src/vlog/async_fifo.v
@@ -21,7 +21,8 @@ module async_fifo
 
     #(
     parameter DSIZE = 8,
-    parameter ASIZE = 4
+    parameter ASIZE = 4,
+    parameter FALLTHROUGH = "TRUE" // First word fall-through
     )(
     input  wire             wclk,
     input  wire             wrst_n,
@@ -78,8 +79,10 @@ module async_fifo
 
     // The DC-RAM 
     fifomem
-    #(DSIZE, ASIZE)
+    #(DSIZE, ASIZE, FALLTHROUGH)
     fifomem (
+    .rclken (rinc),
+    .rclk   (rclk),
     .rdata  (rdata),
     .wdata  (wdata),
     .waddr  (waddr),

--- a/src/vlog/async_fifo.v
+++ b/src/vlog/async_fifo.v
@@ -42,7 +42,9 @@ module async_fifo
     
     // The module synchronizing the read point
     // from read to write domain
-    sync_r2w sync_r2w (
+    sync_r2w
+    #(ASIZE)
+    sync_r2w (
     .wq2_rptr (wq2_rptr),
     .rptr     (rptr),
     .wclk     (wclk),
@@ -51,7 +53,9 @@ module async_fifo
 
     // The module synchronizing the write point
     // from write to read domain
-    sync_w2r sync_w2r (
+    sync_w2r
+    #(ASIZE)
+    sync_w2r (
     .rq2_wptr (rq2_wptr),
     .wptr     (wptr),
     .rclk     (rclk),

--- a/src/vlog/fifo_2mem.v
+++ b/src/vlog/fifo_2mem.v
@@ -47,7 +47,7 @@ module fifomem
   generate
     if (FALLTHROUGH == "TRUE")
       begin : fallthrough
-        always_comb
+        always @*
           rdata = mem[raddr];
       end
     else

--- a/src/vlog/sync_r2w.v
+++ b/src/vlog/sync_r2w.v
@@ -20,15 +20,15 @@
 module sync_r2w
 
     #(
-    parameter ADDRSIZE = 4
+    parameter ASIZE = 4
     )(
     input  wire              wclk,
     input  wire              wrst_n,
-    input  wire [ADDRSIZE:0] rptr,
-    output reg  [ADDRSIZE:0] wq2_rptr
+    input  wire [ASIZE:0] rptr,
+    output reg  [ASIZE:0] wq2_rptr
     );
 
-    reg [ADDRSIZE:0] wq1_rptr;
+    reg [ASIZE:0] wq1_rptr;
 
     always @(posedge wclk or negedge wrst_n) begin
 

--- a/src/vlog/sync_w2r.v
+++ b/src/vlog/sync_w2r.v
@@ -20,15 +20,15 @@
 module sync_w2r 
     
     #(
-    parameter ADDRSIZE = 4
+    parameter ASIZE = 4
     )(
     input  wire              rclk,
     input  wire              rrst_n,
-    output reg  [ADDRSIZE:0] rq2_wptr,
-    input  wire [ADDRSIZE:0] wptr
+    output reg  [ASIZE:0] rq2_wptr,
+    input  wire [ASIZE:0] wptr
     );
     
-    reg [ADDRSIZE:0] rq1_wptr;
+    reg [ASIZE:0] rq1_wptr;
     
     always @(posedge rclk or negedge rrst_n) begin
         


### PR DESCRIPTION
The first commit fixes the address size parameter propagation issue I pointed out in issue #2.

The second adds a new parameter which allows the user to specify whether the FIFO is first word is fall-through or whether you have to read to get it.

Sorry, no tests with this pull request at this stage.