### PR TITLE
Add FuseSoC support

### DIFF
--- a/async_fifo.core
+++ b/async_fifo.core
@@ -1,0 +1,44 @@
+CAPI=2:
+
+name : ::async_fifo:1.0.0-r1
+
+filesets:
+  rtl:
+    files:
+      - src/vlog/fifomem_dp.v
+      - src/vlog/sync_r2w.v
+      - src/vlog/async_bidir_fifo.v
+      - src/vlog/rptr_empty.v
+      - src/vlog/sync_w2r.v
+      - src/vlog/wptr_full.v
+      - src/vlog/fifo_2mem.v
+      - src/vlog/async_bidir_ramif_fifo.v
+      - src/vlog/async_fifo.v
+      - src/vlog/sync_ptr.v
+    file_type : verilogSource
+  tb:
+    files:
+      - sim/test/async_fifo_unit_test.sv : {file_type : systemVerilogSource}
+    depend : [svut, vlog_tb_utils]
+
+targets:
+  default: {filesets : [rtl]}
+
+  sim:
+    default_tool : icarus
+    filesets: [rtl, tb]
+    parameters: [USE_VLOG_TB_UTILS=true]
+    tools:
+      icarus:
+        iverilog_options: [-g2012]
+      modelsim:
+        vlog_options: [-timescale=1ns/1ps]
+      xsim:
+        xelab_options: [--timescale, 1ns/1ns]
+    toplevel : async_fifo_unit_test
+
+parameters:
+  USE_VLOG_TB_UTILS:
+    datatype: bool
+    description: Use vlog_tb_utils for VCD and timeout handling
+    paramtype: vlogdefine

--- a/sim/test/async_fifo_unit_test.sv
+++ b/sim/test/async_fifo_unit_test.sv
@@ -51,9 +51,13 @@ module async_fifo_unit_test;
     always #3 rclk <= ~rclk;
 
     // An example to dump data for visualization
+`ifdef USE_VLOG_TB_UTILS
+   vlog_tb_utils vtu();
+`else
     initial begin
         $dumpvars(0, async_fifo_unit_test);
     end
+`endif
 
     task setup();
     begin

--- a/src/vlog/fifo_2mem.v
+++ b/src/vlog/fifo_2mem.v
@@ -29,8 +29,8 @@ module fifomem
     input wire [ADDRSIZE-1:0] waddr,
     input wire [DATASIZE-1:0] wdata,
     input wire                wfull,
-    input                     rclk,
-    input                     rclken,
+    input wire                rclk,
+    input wire                rclken,
     input wire [ADDRSIZE-1:0] raddr,
     output reg [DATASIZE-1:0] rdata
     );


### PR DESCRIPTION
Adds support for using async_fifo in FuseSoC-based projects.

Also makes it possible to run async_fifo unit tests with different simulators. This has been tested with icarus, modelsim and xsim

To test this

1. Install and initialize fusesoc with `pip install fusesoc` and `fusesoc init`
2. Create an empty workspace directory and run all commands from here
2. Add svut as a FuseSoC library (requires https://github.com/damofthemoon/svut/pull/18). `fusesoc library add svut /path/to/svut` if it's already on your disk, or `fusesoc library add svut https://github.com/damofthemoon/svut` to get the upstream version
3. Add async_fifo as a FuseSoC library `fusesoc library add async_fifo /path/to/async_fifo`
4. Run the simulation `fusesoc run --target=sim async_fifo`. This will use icarus by default. To change tool run with `fusesoc run --target=sim --tool=$tool async_fifo`, where $tool can be icarus, modelsim or xsim. vcs and rivierapro might work too. Haven't tested

To get VCD dumping or force timeout you can add `--vcd` or `--timeout=some_value` at the end of the command-line. To get all options for a specific target, run `fusesoc run --target=sim async_fifo --help`



