### PR TITLE
add parameter for awfull and arempty wire

### DIFF
--- a/rtl/async_fifo.v
+++ b/rtl/async_fifo.v
@@ -9,6 +9,8 @@ module async_fifo
     #(
         parameter DSIZE = 8,
         parameter ASIZE = 4,
+        parameter AWFULLSIZE = 1,
+        parameter AREMPTYSIZE = 1,
         parameter FALLTHROUGH = "TRUE" // First word fall-through without latency
     )(
         input  wire             wclk,
@@ -52,7 +54,7 @@ module async_fifo
 
     // The module handling the write requests
     wptr_full
-    #(ASIZE)
+    #(ASIZE,AWFULLSIZE)
     wptr_full (
     .awfull   (awfull),
     .wfull    (wfull),
@@ -81,7 +83,7 @@ module async_fifo
 
     // The module handling read requests
     rptr_empty
-    #(ASIZE)
+    #(ASIZE,AREMPTYSIZE)
     rptr_empty (
     .arempty  (arempty),
     .rempty   (rempty),

--- a/rtl/rptr_empty.v
+++ b/rtl/rptr_empty.v
@@ -7,7 +7,8 @@
 module rptr_empty
 
     #(
-    parameter ADDRSIZE = 4
+    parameter ADDRSIZE = 4,
+    parameter AREMPTYSIZE = 1
     )(
     input  wire                rclk,
     input  wire                rrst_n,
@@ -39,7 +40,7 @@ module rptr_empty
     assign raddr     = rbin[ADDRSIZE-1:0];
     assign rbinnext  = rbin + (rinc & ~rempty);
     assign rgraynext = (rbinnext >> 1) ^ rbinnext;
-    assign rgraynextm1 = ((rbinnext + 1'b1) >> 1) ^ (rbinnext + 1'b1);
+    assign rgraynextm1 = ((rbinnext + AREMPTYSIZE) >> 1) ^ (rbinnext + AREMPTYSIZE);
 
     //---------------------------------------------------------------
     // FIFO empty when the next rptr == synchronized wptr or on reset

--- a/rtl/wptr_full.v
+++ b/rtl/wptr_full.v
@@ -7,7 +7,8 @@
 module wptr_full
 
 	#(
-		parameter ADDRSIZE = 4
+		parameter ADDRSIZE = 4,
+        parameter AWFULLSIZE = 1
 	)(
 		input  wire                wclk,
 		input  wire                wrst_n,
@@ -37,7 +38,7 @@ module wptr_full
     assign waddr = wbin[ADDRSIZE-1:0];
     assign wbinnext  = wbin + (winc & ~wfull);
     assign wgraynext = (wbinnext >> 1) ^ wbinnext;
-    assign wgraynextp1 = ((wbinnext + 1'b1) >> 1) ^ (wbinnext + 1'b1);
+    assign wgraynextp1 = ((wbinnext + AWFULLSIZE) >> 1) ^ (wbinnext + AWFULLSIZE);
 
     //------------------------------------------------------------------
     // Simplified version of the three necessary full-tests:

--- a/sim/async_fifo_unit_test.sv
+++ b/sim/async_fifo_unit_test.sv
@@ -9,6 +9,8 @@ module async_fifo_unit_test;
 
     parameter DSIZE = 32;
     parameter ASIZE = 4;
+    parameter AREMPTYSIZE = 1;
+    parameter AWFULLSIZE = 1;
 
     reg              wclk;
     reg              wrst_n;
@@ -26,7 +28,9 @@ module async_fifo_unit_test;
     async_fifo
 	#(
 		DSIZE,
-		ASIZE
+		ASIZE,
+        AWFULLSIZE,
+        AREMPTYSIZE
     )
     dut
     (


### PR DESCRIPTION
Issue: https://github.com/dpretet/async_fifo/issues/10

I have verified that the current code passes all the test cases in the simulation.
```bash
 ./flow.sh  sim

INFO: Start Aync FIFO Flow
script/setup.sh: line 12: type: svutRun: not found
INFO: Enable SVUT in PATH
INFO: Start simulation

       ______    ____  ________
      / ___/ |  / / / / /_  __/
      \__ \| | / / / / / / /  
     ___/ /| |/ / /_/ / / /   
    /____/ |___/\____/ /_/

    v1.9.0

SVUT (@ 10:27:19) Run with Icarus Verilog

SVUT (@ 10:27:19) Start async_fifo_unit_test.sv

SVUT (@ 10:27:19) iverilog -g2012 -Wall -o svut.out -f files.f  async_fifo_unit_test.sv 

warning: Some design elements have no explicit time unit and/or
       : time precision. This may cause confusing timing results.
       : Affected design elements are:
       :   -- compilation unit
SVUT (@ 10:27:19) vvp svut.out 

VCD info: dumpfile dump.vcd opened for output.

INFO: Start testsuite << ASYNCFIFO >> (@ 0)

INFO: Starting << Test 0: IDLE >> (@ 0)
SUCCESS: Test 0 pass (@ 200000)

INFO: Starting << Test 1: SINGLE_WRITE_THEN_READ >> (@ 200000)
SUCCESS: Test 1 pass (@ 428000)

INFO: Starting << Test 2: MULTIPLE_WRITE_AND_READ >> (@ 428000)
SUCCESS: Test 2 pass (@ 833000)

INFO: Starting << Test 3: TEST_FULL_FLAG >> (@ 833000)
SUCCESS: Test 3 pass (@ 1104000)

INFO: Starting << Test 4: TEST_EMPTY_FLAG >> (@ 1104000)
SUCCESS: Test 4 pass (@ 1368000)

INFO: Starting << Test 5: TEST_SIMPLE_ALMOST_EMPTY_FLAG >> (@ 1368000)
SUCCESS: Test 5 pass (@ 1676000)

INFO: Starting << Test 6: TEST_SIMPLE_ALMOST_FULL_FLAG >> (@ 1676000)
SUCCESS: Test 6 pass (@ 1944000)

INFO: Starting << Test 7: TEST_CONSECUTIVE_ALMOST_EMPTY_FULL >> (@ 1944000)
SUCCESS: Test 7 pass (@ 2212000)

INFO: Stop testsuite 'ASYNCFIFO' (@ 2212000)
  - Warning number:  0
  - Critical number: 0
  - Error number:    0
  - STATUS: 8/8 test(s) passed

async_fifo_unit_test.sv:245: $finish called at 2212000 (1ps)
SVUT (@ 10:27:19) Stop async_fifo_unit_test.sv

SVUT (@ 10:27:19) Elapsed time: 0:00:00.037137

```

However, I wonder if I should create another unit test case for when AREMPTYSIZE, AWFULLSIZE value is greater than 1?

Thank you very much!