### PR TITLE
Specifc wire size on AREMPTYSIZE and AWWFULLSIZE  parameter

### DIFF
--- a/rtl/rptr_empty.v
+++ b/rtl/rptr_empty.v
@@ -8,7 +8,7 @@ module rptr_empty
 
     #(
     parameter ADDRSIZE = 4,
-    parameter AREMPTYSIZE = 1
+    parameter [ADDRSIZE:0]AREMPTYSIZE = 1
     )(
     input  wire                rclk,
     input  wire                rrst_n,

--- a/rtl/wptr_full.v
+++ b/rtl/wptr_full.v
@@ -8,7 +8,7 @@ module wptr_full
 
 	#(
 		parameter ADDRSIZE = 4,
-        parameter AWFULLSIZE = 1
+        parameter [ADDRSIZE:0]AWFULLSIZE = 1
 	)(
 		input  wire                wclk,
 		input  wire                wrst_n,


### PR DESCRIPTION
See issue: https://github.com/dpretet/async_fifo/issues/12